### PR TITLE
Remove swarm flag

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -344,10 +344,7 @@ func cmdConfig(c *cli.Context) {
 		log.Fatal(err)
 	}
 	dockerHost := cfg.machineUrl
-	if c.IsSet("swarm-discovery") {
-		if !cfg.swarmMaster {
-			log.Fatalf("%s is not a swarm master", cfg.machineName)
-		}
+	if cfg.swarmDiscovery != "" && cfg.swarmMaster {
 		u, err := url.Parse(cfg.swarmHost)
 		if err != nil {
 			log.Fatal(err)
@@ -495,10 +492,7 @@ func cmdEnv(c *cli.Context) {
 	}
 
 	dockerHost := cfg.machineUrl
-	if c.Bool("swarm") {
-		if !cfg.swarmMaster {
-			log.Fatalf("%s is not a swarm master", cfg.machineName)
-		}
+	if cfg.swarmDiscovery != "" && cfg.swarmMaster {
 		u, err := url.Parse(cfg.swarmHost)
 		if err != nil {
 			log.Fatal(err)

--- a/docs/index.md
+++ b/docs/index.md
@@ -312,14 +312,14 @@ To connect to the Swarm master, use `docker-machine env --swarm swarm-master`
 For example:
 
 ```
-$ docker-machine env --swarm swarm-master
+$ docker-machine env swarm-master
 export DOCKER_TLS_VERIFY=yes
 export DOCKER_CERT_PATH=/home/ehazlett/.docker/machines/.client
 export DOCKER_HOST=tcp://192.168.99.100:3376
 ```
 
 You can load this into your environment using
-`$(docker-machine env --swarm swarm-master)`.
+`$(docker-machine env swarm-master)`.
 
 Now you can use the Docker CLI to query:
 

--- a/host_test.go
+++ b/host_test.go
@@ -36,7 +36,6 @@ func getTestDriverFlags() *DriverOptionsMock {
 		Data: map[string]interface{}{
 			"name":            name,
 			"url":             "unix:///var/run/docker.sock",
-			"swarm":           false,
 			"swarm-host":      "",
 			"swarm-master":    false,
 			"swarm-discovery": "",

--- a/store.go
+++ b/store.go
@@ -68,7 +68,7 @@ func (s *Store) Create(name string, driverName string, flags drivers.DriverOptio
 		return host, err
 	}
 
-	if flags.Bool("swarm") {
+	if flags.String("swarm-discovery") != "" {
 		log.Info("Configuring Swarm...")
 
 		discovery := flags.String("swarm-discovery")

--- a/store_test.go
+++ b/store_test.go
@@ -41,7 +41,6 @@ func getDefaultTestDriverFlags() *DriverOptionsMock {
 		Data: map[string]interface{}{
 			"name":            "test",
 			"url":             "unix:///var/run/docker.sock",
-			"swarm":           false,
 			"swarm-host":      "",
 			"swarm-master":    false,
 			"swarm-discovery": "",


### PR DESCRIPTION
More updates to remove the `--swarm` flag on `create`, `config` and `env`. 

Note: with the `--swarm` removal you can no longer access the engine direct when using `env` or `config`.  Only swarm can be accessed.